### PR TITLE
Added buffer width and height for graphic device.

### DIFF
--- a/Game1.cs
+++ b/Game1.cs
@@ -52,7 +52,12 @@ namespace Project
 
         public Game1()
         {
+            // Since we're in constructor, no need to call GraphicsDeviceManager.ApplyChanges()
+            // :)
             _graphics = new GraphicsDeviceManager(this);
+            _graphics.PreferredBackBufferWidth = 1600; // Set width
+            _graphics.PreferredBackBufferHeight = 900; // Set height
+
             Content.RootDirectory = "Content";
             IsMouseVisible = true;
         }


### PR DESCRIPTION
## Related Issue(s)

- #50 

## How does this PR address the mentioned issue(s)?

Added two simple properties to the graphics device to allow manual setting of width and height. For widest compatibility across different resolutions, I've set the size to 1600 x 900 to keep the same aspect ration as before.

## Notes for code reviewers

The resolution can be changed simply by modifying the properties shown in the Game1 constructor. So easy yo mama could do it ;)

```
 _graphics.PreferredBackBufferWidth = 1600; // Set width
 _graphics.PreferredBackBufferHeight = 900; // Set height
```