### PR TITLE
Player death

### DIFF
--- a/Game1.cs
+++ b/Game1.cs
@@ -84,7 +84,8 @@ namespace Project
 
             if (player.health < 0)
             {
-                new QuitCommand(this);
+                RestartGameCommand reset = new RestartGameCommand(this);
+                reset.Execute();
             }
         }
 

--- a/Game1.cs
+++ b/Game1.cs
@@ -73,7 +73,7 @@ namespace Project
             this.roomManager.LoadRoomsFromContent(Content, gameRenderer);
             this.roomManager.AssignPlayer(this.player);
             this.gameRenderer.PlayerCharacter = this.player;
-            this.updater = new Updater(this.roomManager, this.player, this);
+            this.updater = new Updater(this.roomManager, this.player, new RestartGameCommand(this));
             this.updater.RegisterController(this.CreateKeyboardController());
         }
 

--- a/Game1.cs
+++ b/Game1.cs
@@ -73,7 +73,7 @@ namespace Project
             this.roomManager.LoadRoomsFromContent(Content, gameRenderer);
             this.roomManager.AssignPlayer(this.player);
             this.gameRenderer.PlayerCharacter = this.player;
-            this.updater = new Updater(this.roomManager, this.player);
+            this.updater = new Updater(this.roomManager, this.player, this);
             this.updater.RegisterController(this.CreateKeyboardController());
         }
 
@@ -81,12 +81,6 @@ namespace Project
         {
             this.updater.Update(gameTime);
             base.Update(gameTime);
-
-            if (player.health < 0)
-            {
-                RestartGameCommand reset = new RestartGameCommand(this);
-                reset.Execute();
-            }
         }
 
         protected override void Draw(GameTime gameTime)

--- a/Game1.cs
+++ b/Game1.cs
@@ -81,6 +81,11 @@ namespace Project
         {
             this.updater.Update(gameTime);
             base.Update(gameTime);
+
+            if (player.health < 0)
+            {
+                new QuitCommand(this);
+            }
         }
 
         protected override void Draw(GameTime gameTime)

--- a/Packages/Characters/Player.cs
+++ b/Packages/Characters/Player.cs
@@ -5,6 +5,8 @@ using Project.Characters.Enums;
 using Project.Factories;
 using Project.Rooms.Blocks.ConcreteClasses;
 using Project.Sprites;
+using Project.Enemies.EnemyClasses;
+using Project.Commands.GameLogicCommands;
 
 namespace Project.Characters
 {
@@ -15,9 +17,8 @@ namespace Project.Characters
         private Rectangle _previousLocation;
         public Direction LastDirection { get; private set; }
         public Direction SpriteType { get; set; }
-        public Boolean isDamaged;
         public Vector2 velocity;
-
+        public int health;
         private float elapsedTime;
 
         public Player()
@@ -26,9 +27,9 @@ namespace Project.Characters
             Location = new Rectangle(36, 36, 20, 44);
             this._previousLocation = Location;
             velocity = new Vector2(0, 0);
+            health = 5;
 
             LastDirection = Direction.Down;
-            isDamaged = false;
 
             // Initially use a "stopped" sprite (down facing)
             Sprite = PlayerSpriteFactory.Instance.NewStoppedPlayerSprite(Direction.Down, false);
@@ -54,8 +55,8 @@ namespace Project.Characters
 
             SpriteType = LastDirection;
             Sprite.State = CharacterState.Stopped;
-
-            ChangeSprite(PlayerSpriteFactory.Instance.NewStoppedPlayerSprite(SpriteType, isDamaged));
+            
+            ChangeSprite(PlayerSpriteFactory.Instance.NewStoppedPlayerSprite(SpriteType, health < 5));
         }
 
         public void Update(GameTime gameTime)
@@ -73,6 +74,7 @@ namespace Project.Characters
                 Sprite.Update();
                 elapsedTime = 0f;
             }
+
         }
 
         public void Draw(SpriteBatch spriteBatch, Rectangle? position = null)
@@ -87,6 +89,11 @@ namespace Project.Characters
             {
                 this.Location = this._previousLocation;
             }
+            if (collider is Enemy)
+            {
+                health -= 1;
+            }
+
         }
     }
 }

--- a/Packages/Characters/Player.cs
+++ b/Packages/Characters/Player.cs
@@ -7,6 +7,7 @@ using Project.Rooms.Blocks.ConcreteClasses;
 using Project.Sprites;
 using Project.Enemies.EnemyClasses;
 using Project.Commands.GameLogicCommands;
+using Project.Items;
 
 namespace Project.Characters
 {
@@ -57,7 +58,7 @@ namespace Project.Characters
             SpriteType = LastDirection;
             Sprite.State = CharacterState.Stopped;
             
-            ChangeSprite(PlayerSpriteFactory.Instance.NewStoppedPlayerSprite(SpriteType, health < 5));
+            ChangeSprite(PlayerSpriteFactory.Instance.NewStoppedPlayerSprite(SpriteType, invincibleTime > 0));
         }
 
         public void Update(GameTime gameTime)
@@ -98,6 +99,10 @@ namespace Project.Characters
                 invincibleTime = 1;
             }
 
+            if (collider is Item)
+            {
+                health += 2;
+            }
         }
     }
 }

--- a/Packages/Characters/Player.cs
+++ b/Packages/Characters/Player.cs
@@ -13,6 +13,7 @@ namespace Project.Characters
     {
         public Rectangle Location { get; set; }
         public int PlayerHealthEffect { get => 0; }
+        public bool IsPassable { get => true; }
 
         private Rectangle _previousLocation;
         public ISprite Sprite { get; private set; }

--- a/Packages/Characters/Player.cs
+++ b/Packages/Characters/Player.cs
@@ -2,10 +2,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Project.Characters.Enums;
 using Project.Factories;
-using Project.Rooms.Blocks.ConcreteClasses;
 using Project.Sprites;
-using Project.Enemies.EnemyClasses;
-using Project.Items;
 
 namespace Project.Characters
 {

--- a/Packages/Characters/Player.cs
+++ b/Packages/Characters/Player.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Project.Characters.Enums;
@@ -6,21 +5,24 @@ using Project.Factories;
 using Project.Rooms.Blocks.ConcreteClasses;
 using Project.Sprites;
 using Project.Enemies.EnemyClasses;
-using Project.Commands.GameLogicCommands;
 using Project.Items;
 
 namespace Project.Characters
 {
     public class Player : IGameObject
     {
-        public ISprite Sprite { get; private set; }
         public Rectangle Location { get; set; }
+        public int PlayerHealthEffect { get => 0; }
+
         private Rectangle _previousLocation;
+        public ISprite Sprite { get; private set; }
         public Direction LastDirection { get; private set; }
         public Direction SpriteType { get; set; }
         public Vector2 velocity;
+
         public int health;
         public float invincibleTime;
+
         private float elapsedTime;
 
         public Player()
@@ -57,7 +59,7 @@ namespace Project.Characters
 
             SpriteType = LastDirection;
             Sprite.State = CharacterState.Stopped;
-            
+
             ChangeSprite(PlayerSpriteFactory.Instance.NewStoppedPlayerSprite(SpriteType, invincibleTime > 0));
         }
 

--- a/Packages/Characters/Player.cs
+++ b/Packages/Characters/Player.cs
@@ -90,20 +90,17 @@ namespace Project.Characters
 
         public void CollideWith(IGameObject collider)
         {
-            // TODO:Implement, include a check for what *kind* of game object it is
-            if (collider is SolidBlock)
+            if (!collider.IsPassable)
             {
                 this.Location = this._previousLocation;
             }
-            if (collider is Enemy && invincibleTime < 0)
-            {
-                health -= 1;
-                invincibleTime = 1;
-            }
 
-            if (collider is Item)
+            int collisionHealthEffect = collider.PlayerHealthEffect;
+            health += collisionHealthEffect;
+
+            if (collisionHealthEffect < 0) // Causing damage
             {
-                health += 2;
+                invincibleTime = 1;
             }
         }
     }

--- a/Packages/Characters/Player.cs
+++ b/Packages/Characters/Player.cs
@@ -19,6 +19,7 @@ namespace Project.Characters
         public Direction SpriteType { get; set; }
         public Vector2 velocity;
         public int health;
+        public float invincibleTime;
         private float elapsedTime;
 
         public Player()
@@ -28,7 +29,7 @@ namespace Project.Characters
             this._previousLocation = Location;
             velocity = new Vector2(0, 0);
             health = 5;
-
+            invincibleTime = 0;
             LastDirection = Direction.Down;
 
             // Initially use a "stopped" sprite (down facing)
@@ -74,7 +75,9 @@ namespace Project.Characters
                 Sprite.Update();
                 elapsedTime = 0f;
             }
-
+            // Count down the invincibility frame timer
+            invincibleTime -= (float)gameTime.ElapsedGameTime.TotalSeconds;
+            System.Diagnostics.Debug.WriteLine(health);
         }
 
         public void Draw(SpriteBatch spriteBatch, Rectangle? position = null)
@@ -89,9 +92,10 @@ namespace Project.Characters
             {
                 this.Location = this._previousLocation;
             }
-            if (collider is Enemy)
+            if (collider is Enemy && invincibleTime < 0)
             {
                 health -= 1;
+                invincibleTime = 1;
             }
 
         }

--- a/Packages/Characters/Player.cs
+++ b/Packages/Characters/Player.cs
@@ -78,7 +78,6 @@ namespace Project.Characters
             }
             // Count down the invincibility frame timer
             invincibleTime -= (float)gameTime.ElapsedGameTime.TotalSeconds;
-            System.Diagnostics.Debug.WriteLine(health);
         }
 
         public void Draw(SpriteBatch spriteBatch, Rectangle? position = null)

--- a/Packages/Commands/PlayerCommands/AttackCommand.cs
+++ b/Packages/Commands/PlayerCommands/AttackCommand.cs
@@ -17,7 +17,7 @@ namespace Project.Commands.PlayerCommands
         {
 
             if (_player.Sprite.State != CharacterState.Attacking)
-                _player.ChangeSprite(PlayerSpriteFactory.Instance.NewAttackingPlayerSprite(_player.LastDirection, _player.isDamaged));
+                _player.ChangeSprite(PlayerSpriteFactory.Instance.NewAttackingPlayerSprite(_player.LastDirection, _player.health < 5));
 
         }
     }

--- a/Packages/Commands/PlayerCommands/AttackCommand.cs
+++ b/Packages/Commands/PlayerCommands/AttackCommand.cs
@@ -17,7 +17,7 @@ namespace Project.Commands.PlayerCommands
         {
 
             if (_player.Sprite.State != CharacterState.Attacking)
-                _player.ChangeSprite(PlayerSpriteFactory.Instance.NewAttackingPlayerSprite(_player.LastDirection, _player.health < 5));
+                _player.ChangeSprite(PlayerSpriteFactory.Instance.NewAttackingPlayerSprite(_player.LastDirection, _player.invincibleTime > 0));
 
         }
     }

--- a/Packages/Commands/PlayerCommands/DamageCommand.cs
+++ b/Packages/Commands/PlayerCommands/DamageCommand.cs
@@ -14,6 +14,7 @@ namespace Project.Commands.PlayerCommands
         public void Execute()
         {
             _player.health -= 1;
+            _player.invincibleTime = 1;
         }
     }
 }

--- a/Packages/Commands/PlayerCommands/DamageCommand.cs
+++ b/Packages/Commands/PlayerCommands/DamageCommand.cs
@@ -13,7 +13,7 @@ namespace Project.Commands.PlayerCommands
 
         public void Execute()
         {
-            _player.isDamaged = !_player.isDamaged;
+            _player.health -= 1;
         }
     }
 }

--- a/Packages/Commands/PlayerCommands/MoveCommand.cs
+++ b/Packages/Commands/PlayerCommands/MoveCommand.cs
@@ -43,7 +43,7 @@ namespace Project.Commands.PlayerCommands
             if (_player.Sprite.State != CharacterState.Walking
                 || (_player.Sprite.State == CharacterState.Walking
                   && _direction != _player.LastDirection))
-                _player.ChangeSprite(PlayerSpriteFactory.Instance.NewWalkingPlayerSprite(_direction, _player.isDamaged));
+                _player.ChangeSprite(PlayerSpriteFactory.Instance.NewWalkingPlayerSprite(_direction, _player.health < 5));
 
             _player.SpriteType = _direction;
             _player.Sprite.State = CharacterState.Walking;

--- a/Packages/Commands/PlayerCommands/MoveCommand.cs
+++ b/Packages/Commands/PlayerCommands/MoveCommand.cs
@@ -43,7 +43,7 @@ namespace Project.Commands.PlayerCommands
             if (_player.Sprite.State != CharacterState.Walking
                 || (_player.Sprite.State == CharacterState.Walking
                   && _direction != _player.LastDirection))
-                _player.ChangeSprite(PlayerSpriteFactory.Instance.NewWalkingPlayerSprite(_direction, _player.health < 5));
+                _player.ChangeSprite(PlayerSpriteFactory.Instance.NewWalkingPlayerSprite(_direction, _player.invincibleTime > 0));
 
             _player.SpriteType = _direction;
             _player.Sprite.State = CharacterState.Walking;

--- a/Packages/Enemies/EnemyClasses/Enemy.cs
+++ b/Packages/Enemies/EnemyClasses/Enemy.cs
@@ -10,6 +10,7 @@ namespace Project.Enemies.EnemyClasses
     {
         public Rectangle Location { get; private set; }
         public virtual int PlayerHealthEffect { get => -2; }
+        public bool IsPassable { get => true; }
 
         public float Speed { get; set; }
         private IEnemyState CurrentState { get; set; }

--- a/Packages/Enemies/EnemyClasses/Enemy.cs
+++ b/Packages/Enemies/EnemyClasses/Enemy.cs
@@ -9,6 +9,8 @@ namespace Project.Enemies.EnemyClasses
     public abstract class Enemy : IEnemy
     {
         public Rectangle Location { get; private set; }
+        public virtual int PlayerHealthEffect { get => -2; }
+
         public float Speed { get; set; }
         private IEnemyState CurrentState { get; set; }
         protected Direction lastDirection = Direction.Left;

--- a/Packages/Enemies/EnemyManager.cs
+++ b/Packages/Enemies/EnemyManager.cs
@@ -44,6 +44,11 @@ namespace Project.Enemies
                 currentEnemyIndex++;
         }
 
+        public Enemy ReturnEnemy()
+        {
+            return enemies[currentEnemyIndex];
+        }
+
         public void Draw(SpriteBatch spriteBatch)
         {
             foreach (Enemy enemy in enemies)

--- a/Packages/IGameObject.cs
+++ b/Packages/IGameObject.cs
@@ -6,6 +6,7 @@ namespace Project
     {
         Rectangle Location { get; }
         int PlayerHealthEffect { get; }
+        bool IsPassable { get; }
 
         void CollideWith(IGameObject collider);
     }

--- a/Packages/IGameObject.cs
+++ b/Packages/IGameObject.cs
@@ -5,6 +5,8 @@ namespace Project
     public interface IGameObject
     {
         Rectangle Location { get; }
+        int PlayerHealthEffect { get; }
+
         void CollideWith(IGameObject collider);
     }
 }

--- a/Packages/Items/Item.cs
+++ b/Packages/Items/Item.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Project.Characters;
 using Project.Sprites;
 
 namespace Project.Items
@@ -25,7 +26,12 @@ namespace Project.Items
 
         public virtual void CollideWith(IGameObject collider)
         {
-            // TODO: Implement this
+            if (collider is Player)
+            {
+                //For now we will just set the location to a far away place
+                //I need to figure out how to make an item delete itself without access to the item manager?
+                Location = new Rectangle(1000, 1000, 1000, 1000);
+            }
         }
     }
 }

--- a/Packages/Items/Item.cs
+++ b/Packages/Items/Item.cs
@@ -9,6 +9,7 @@ namespace Project.Items
     {
         public abstract Rectangle Location { get; set; }
         public virtual int PlayerHealthEffect { get => 2; }
+        public bool IsPassable { get => true; }
 
         public abstract float Speed { get; set; }
 

--- a/Packages/Items/Item.cs
+++ b/Packages/Items/Item.cs
@@ -7,8 +7,10 @@ namespace Project.Items
 {
     public abstract class Item : IItem
     {
-        public abstract float Speed { get; set; }
         public abstract Rectangle Location { get; set; }
+        public virtual int PlayerHealthEffect { get => 2; }
+
+        public abstract float Speed { get; set; }
 
         public ISprite Sprite { get; }
 

--- a/Packages/Rooms/BaseRoom.cs
+++ b/Packages/Rooms/BaseRoom.cs
@@ -78,12 +78,18 @@ namespace Project.Packages
         public void Update(GameTime gameTime)
         {
             this._enemyManager.Update(gameTime);
+            
+            //Player and Enemy Collision
             for (int i = 0; i < this._enemyManager.enemies.Count; i++)
             {
                 this._enemyManager.SwitchToNextEnemy();
                 this._collisionManager.Collide(this._player, this._enemyManager.ReturnEnemy());
             }
-
+            //Player and Item Collison
+            for (int i = 0; i < this._itemManager.GetWorldItems().Count; i++)
+            { 
+                this._collisionManager.Collide(this._player, this._itemManager.GetWorldItems()[i]);
+            }
             //Player and Block Collison
             for (int i = 0; i < this.internalMap.GetLength(0); i++)
             {

--- a/Packages/Rooms/BaseRoom.cs
+++ b/Packages/Rooms/BaseRoom.cs
@@ -87,7 +87,7 @@ namespace Project.Packages
             }
             //Player and Item Collison
             for (int i = 0; i < this._itemManager.GetWorldItems().Count; i++)
-            { 
+            {
                 this._collisionManager.Collide(this._player, this._itemManager.GetWorldItems()[i]);
             }
             //Player and Block Collison
@@ -99,7 +99,7 @@ namespace Project.Packages
                     {
                         this._collisionManager.Collide(this._player, this.internalMap[i, j]);
                     }
-                }   
+                }
             }
         }
     }

--- a/Packages/Rooms/BaseRoom.cs
+++ b/Packages/Rooms/BaseRoom.cs
@@ -78,7 +78,13 @@ namespace Project.Packages
         public void Update(GameTime gameTime)
         {
             this._enemyManager.Update(gameTime);
+            for (int i = 0; i < this._enemyManager.enemies.Count; i++)
+            {
+                this._enemyManager.SwitchToNextEnemy();
+                this._collisionManager.Collide(this._player, this._enemyManager.ReturnEnemy());
+            }
 
+            //Player and Block Collison
             for (int i = 0; i < this.internalMap.GetLength(0); i++)
             {
                 for (int j = 0; j < this.internalMap.GetLength(1); j++)
@@ -87,7 +93,7 @@ namespace Project.Packages
                     {
                         this._collisionManager.Collide(this._player, this.internalMap[i, j]);
                     }
-                }
+                }   
             }
         }
     }

--- a/Packages/Rooms/Blocks/ConcreteClasses/SolidBlock.cs
+++ b/Packages/Rooms/Blocks/ConcreteClasses/SolidBlock.cs
@@ -5,6 +5,9 @@ namespace Project.Rooms.Blocks.ConcreteClasses
 {
     public class SolidBlock : IBlock
     {
+        public Rectangle Location { get => this._renderedLocation; }
+        public int PlayerHealthEffect { get => 0; }
+
         private Texture2D _texture;
         private Rectangle _textureSource;
 
@@ -12,7 +15,6 @@ namespace Project.Rooms.Blocks.ConcreteClasses
         private int _verticalBlockInstances;
 
         private Rectangle _renderedLocation;
-        public Rectangle Location { get => this._renderedLocation; }
         public int LeftXCoord { get { return this._renderedLocation.X; } }
         public int RightXCoord
         {

--- a/Packages/Rooms/Blocks/ConcreteClasses/SolidBlock.cs
+++ b/Packages/Rooms/Blocks/ConcreteClasses/SolidBlock.cs
@@ -7,6 +7,7 @@ namespace Project.Rooms.Blocks.ConcreteClasses
     {
         public Rectangle Location { get => this._renderedLocation; }
         public int PlayerHealthEffect { get => 0; }
+        public bool IsPassable { get => false; }
 
         private Texture2D _texture;
         private Rectangle _textureSource;

--- a/Packages/Updater.cs
+++ b/Packages/Updater.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using Microsoft.Xna.Framework;
 using Project.Characters;
+using Project.Commands;
 using Project.Commands.GameLogicCommands;
 using Project.Controllers;
 using Project.Rooms;
@@ -15,14 +16,14 @@ namespace Project
     {
         private RoomManager _roomManager;
         private Player _player;
-        private Game1 _game1;
+        private ICommand _restartCommand;
         private List<IController> _controllers;
 
-        public Updater(RoomManager roomManager, Player player, Game1 game1)
+        public Updater(RoomManager roomManager, Player player, ICommand restart)
         {
             this._player = player;
             this._roomManager = roomManager;
-            this._game1 = game1;
+            this._restartCommand = restart;
             this._controllers = new List<IController>();
         }
 
@@ -44,8 +45,7 @@ namespace Project
 
             if (_player.health <= 0)
             {
-                RestartGameCommand reset = new RestartGameCommand(_game1);
-                reset.Execute();
+                _restartCommand.Execute();
             }
         }
     }

--- a/Packages/Updater.cs
+++ b/Packages/Updater.cs
@@ -1,9 +1,7 @@
 using System.Collections.Generic;
-using System.Numerics;
 using Microsoft.Xna.Framework;
 using Project.Characters;
 using Project.Commands;
-using Project.Commands.GameLogicCommands;
 using Project.Controllers;
 using Project.Rooms;
 

--- a/Packages/Updater.cs
+++ b/Packages/Updater.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
+using System.Numerics;
 using Microsoft.Xna.Framework;
 using Project.Characters;
+using Project.Commands.GameLogicCommands;
 using Project.Controllers;
 using Project.Rooms;
 
@@ -13,12 +15,14 @@ namespace Project
     {
         private RoomManager _roomManager;
         private Player _player;
+        private Game1 _game1;
         private List<IController> _controllers;
 
-        public Updater(RoomManager roomManager, Player player)
+        public Updater(RoomManager roomManager, Player player, Game1 game1)
         {
             this._player = player;
             this._roomManager = roomManager;
+            this._game1 = game1;
             this._controllers = new List<IController>();
         }
 
@@ -37,6 +41,12 @@ namespace Project
             this._player.Update(gameTime); // Keep this here because update logic
                                            // might change *outside* of a room
             this._roomManager.Update(gameTime);
+
+            if (_player.health <= 0)
+            {
+                RestartGameCommand reset = new RestartGameCommand(_game1);
+                reset.Execute();
+            }
         }
     }
 }


### PR DESCRIPTION
## Related Issue(s)

#77 

## How does this PR address the mentioned issue(s)?

The player has an internal health variable. The health is decreased when colliding with an enemy and sets an invincibility timer for when it can be hit again. The sprite changes to the damaged sprite while it is invincible. The player has 5 health, and when it is decreased to 0, the RestartGameCommand is run. When the player collides with the item, the health is increased by 2, and the item is teleported off screen. 

## Notes for code reviewers

The health bar that will be implemented, should use the public health variable. 
For the future, we could have different sprites for multiple damaged states, as well as a sprite for the "invincibility frames". 
Once we have enemy projectiles fully functional, we need to add the ability for the player to be damaged by them as well.
While not part of this issue, if we plan to add the multiple item types again, there needs to be a way to differentiate the behavior when colliding. Also, a way for items to be deleted from the world within the item itself.
