### PR TITLE
[Hotfix] Avoid lazy recursion in KeyboardController

### DIFF
--- a/Packages/Controllers/KeyboardController.cs
+++ b/Packages/Controllers/KeyboardController.cs
@@ -8,7 +8,7 @@ namespace Project.Controllers
     public class KeyboardController : IController
     {
         private Dictionary<Keys, ICommand> _commands;
-        private IEnumerable<Keys> _stillPressed;
+        private Keys[] _stillPressed;
         private ICommand _defaultCommand;
 
         public KeyboardController()
@@ -44,8 +44,8 @@ namespace Project.Controllers
 
             // Keep an active log of currently pressed keys so that "holding down" a key
             //  is ignored.
-            _stillPressed = currentlyPressed.Union<Keys>(_stillPressed);
-            _stillPressed = currentlyPressed.Intersect<Keys>(_stillPressed);
+            _stillPressed = currentlyPressed.Union<Keys>(_stillPressed).ToArray();
+            _stillPressed = currentlyPressed.Intersect<Keys>(_stillPressed).ToArray();
         }
     }
 }


### PR DESCRIPTION
## Related Issue(s)

- #89 

## How does this PR address the mentioned issue(s)?

Pretty straightforwardly. #89 describes a stack overflow bug that this PR fixes. More specifically, running Union and Intersect back-to-back seemed to make weird recursion issues occur, so this adds a step to explicitly turn them into arrays.

## Notes for code reviewers

There are two separate circumstances that caused crashes, here are the ways to test them:

- Open the game, put on a timer for an egregiously long time (20 minutes, e.g.) and then let it sit. Come back, and press any key. Pre-hotfix, this would immediately cause a crash with hundreds of recursions on the stack trace.
- Open the game and just press movement keys for 3-5 minutes. This either caused a crash or at least a *significant* slowdown in pre-hotfix testing. Maybe put on some headphones in the meantime; it's pretty boring to do this! 😅