### PR TITLE
Enemy health

### DIFF
--- a/Packages/Characters/Player.cs
+++ b/Packages/Characters/Player.cs
@@ -226,5 +226,9 @@ namespace Project.Characters
             public int Dx { get; set; }
             public int Dy { get; set; }
         }
+
+        public IItem ActiveItem => _activeItem;
+        public bool IsAttacking() => Sprite.State == CharacterState.Attacking && _activeItem != null;
+
     }
 }

--- a/Packages/Enemies/EnemyClasses/Enemy.cs
+++ b/Packages/Enemies/EnemyClasses/Enemy.cs
@@ -23,6 +23,9 @@ namespace Project.Enemies.EnemyClasses
         public ISprite currentAnimation;
         private float elapsedTime;
 
+        private float hurtCooldown = 0f;
+        private const float HurtDelay = 1.0f;
+
         private Rectangle lastLocation;
 
         public int Health { get; private set; } = 3;
@@ -141,13 +144,21 @@ namespace Project.Enemies.EnemyClasses
 
         public virtual void Update(GameTime gameTime)
         {
+            if (hurtCooldown > 0)
+                hurtCooldown -= (float)gameTime.ElapsedGameTime.TotalSeconds;
+
             UpdateState(gameTime);
             UpdateAnimation(gameTime);
         }
 
         public virtual void TakeDamage(int amount)
         {
-            Health -= amount;
+            if (hurtCooldown <= 0)
+            {
+                Health -= amount;
+                hurtCooldown = HurtDelay;
+                System.Console.Out.WriteLine($"Enemy took {amount} damage. Remaining: {Health}");
+            }
         }
 
         public bool IsDead => Health <= 0;

--- a/Packages/Enemies/EnemyClasses/Enemy.cs
+++ b/Packages/Enemies/EnemyClasses/Enemy.cs
@@ -157,7 +157,6 @@ namespace Project.Enemies.EnemyClasses
             {
                 Health -= amount;
                 hurtCooldown = HurtDelay;
-                System.Console.Out.WriteLine($"Enemy took {amount} damage. Remaining: {Health}");
             }
         }
 

--- a/Packages/Enemies/EnemyClasses/Enemy.cs
+++ b/Packages/Enemies/EnemyClasses/Enemy.cs
@@ -144,5 +144,12 @@ namespace Project.Enemies.EnemyClasses
             UpdateState(gameTime);
             UpdateAnimation(gameTime);
         }
+
+        public virtual void TakeDamage(int amount)
+        {
+            Health -= amount;
+        }
+
+        public bool IsDead => Health <= 0;
     }
 }

--- a/Packages/Enemies/EnemyClasses/Enemy.cs
+++ b/Packages/Enemies/EnemyClasses/Enemy.cs
@@ -25,6 +25,8 @@ namespace Project.Enemies.EnemyClasses
 
         private Rectangle lastLocation;
 
+        public int Health { get; private set; } = 3;
+
         public Enemy(Rectangle initialPosition)
         {
             Location = initialPosition;

--- a/Packages/Enemies/EnemyManager.cs
+++ b/Packages/Enemies/EnemyManager.cs
@@ -57,9 +57,13 @@ namespace Project.Enemies
 
         public void Update(GameTime gameTime)
         {
-            foreach (Enemy enemy in enemies)
+            for (int i = enemies.Count - 1; i >= 0; i--)
             {
-                enemy.Update(gameTime);
+                enemies[i].Update(gameTime);
+                if (enemies[i].IsDead)
+                {
+                    enemies.RemoveAt(i);
+                }
             }
         }
     }

--- a/Packages/Rooms/BaseRoom.cs
+++ b/Packages/Rooms/BaseRoom.cs
@@ -122,6 +122,21 @@ namespace Project.Packages
                     }
                 }
             }
+            // Enemy and Attack Collisions
+            if (_player.IsAttacking())
+            {
+                var attack = _player.ActiveItem;
+                if (attack != null)
+                {
+                    foreach (var enemy in _enemyManager.enemies)
+                    {
+                        if (attack.Location.Intersects(enemy.Location))
+                        {
+                            enemy.TakeDamage(1);
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Related Issue(s)

#115 

## How does this PR address the mentioned issue(s)?

This PR modifies Enemy by adding a health attribute. It adds methods to take damage and track if enemies are dead. The enemy manager was also updated to cycle through when updating to remove any dead enemies.  There is a cooldown delay so the enemies don't die instantly. I added some methods to player to return the active item (this should be useful in the different item/projectile collisions) as well as a method to return if the player is attacking. 

## Notes for code reviewers

Will need to integrate this with the projectile collisions with AJ's code. Will also need to decouple the items and basic attack. I'm assuming holding no item will give the slash, then sword, bomb etc have their own sequence. 
