### PR TITLE
Adjust Iframes fixed

### DIFF
--- a/Packages/Characters/Player.cs
+++ b/Packages/Characters/Player.cs
@@ -8,6 +8,7 @@ using Project.Items;
 using Project.Packages.Sounds;
 using Project.Rooms.Blocks.ConcreteClasses;
 using Project.Sprites;
+using Project.Commands.PlayerCommands;
 
 namespace Project.Characters
 {
@@ -215,7 +216,7 @@ namespace Project.Characters
                 if (collisionHealthEffect < 0) // Causing damage
                 {
                     SoundEffectManager.Instance.playDamage();
-                    invincibleTime = 1;
+                    new DamageCommand(this).Execute();
                 }
                 if (collisionHealthEffect > 0) // Healing
                 {

--- a/Packages/Commands/PlayerCommands/DamageCommand.cs
+++ b/Packages/Commands/PlayerCommands/DamageCommand.cs
@@ -14,7 +14,7 @@ namespace Project.Commands.PlayerCommands
         public void Execute()
         {
             _player.health -= 1;
-            _player.invincibleTime = 1;
+            _player.invincibleTime = 2f; // 2.0 second of iFrames
         }
     }
 }


### PR DESCRIPTION
Refactored Player.cs to leverage the DamageCommand.cs instead of hardcoding iframes.

Iframes now synced up to damaged sprite animation correctly.

## Related Issue(s)
- #105 

## How does this PR address the mentioned issue(s)?

Refactored Player.cs to leverage the DamageCommand.cs instead of hardcoding iframes.

## Notes for code reviewers
Discussed in person.
